### PR TITLE
fix: add namespace (AGP8)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,6 +22,9 @@ allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    if (project.android.hasProperty("namespace")) {
+        namespace 'io.blockshake.ledger'
+    }
     compileSdkVersion 31
 
     compileOptions {


### PR DESCRIPTION
AGP8 requires build.gradle to add namespace.

```plain
 > Could not create an instance of type com.android.build.api.variant.impl.LibraryVariantBuilderImpl.
   > Namespace not specified. Specify a namespace in the module's build file: /home/runner/.pub-cache/hosted/pub.dev/ledger_usb-1.0.0/android/build.gradle. See https://d.android.com/r/tools/upgrade-assistant/set-namespace for information about setting the namespace.
```